### PR TITLE
Add Wikipedia image display to wiki game articles

### DIFF
--- a/src/components/wiki-game/Article.tsx
+++ b/src/components/wiki-game/Article.tsx
@@ -20,6 +20,11 @@ export const Article: React.FC<ArticleProps> = ({
   maxScore,
 }) => {
   const { content, links, title } = article;
+  const {
+    imageUrl,
+    isLoading: imageLoading,
+    error: imageError,
+  } = useWikipediaImage(title);
 
   const renderArticleContent = () => {
     return (

--- a/src/components/wiki-game/Article.tsx
+++ b/src/components/wiki-game/Article.tsx
@@ -1,7 +1,8 @@
 import React from "react";
 import { Article as ArticleType, Link as LinkType } from "@/types/wiki-game";
 import { cn } from "@/lib/utils";
-import { Edit3 } from "lucide-react";
+import { Edit3, ImageIcon, Loader2 } from "lucide-react";
+import { useWikipediaImage } from "@/hooks/use-wikipedia-image";
 
 interface ArticleProps {
   article: ArticleType;

--- a/src/components/wiki-game/Article.tsx
+++ b/src/components/wiki-game/Article.tsx
@@ -82,7 +82,10 @@ export const Article: React.FC<ArticleProps> = ({
   const renderWikipediaImage = () => {
     if (imageLoading) {
       return (
-        <div className="w-full sm:w-48 h-32 sm:h-36 bg-gray-100 rounded-lg flex items-center justify-center mb-4 sm:mb-0 sm:mr-4 flex-shrink-0">
+        <div
+          className="w-full sm:w-64 bg-gray-100 rounded-lg flex items-center justify-center mb-4 sm:mb-0 sm:mr-6 flex-shrink-0"
+          style={{ minHeight: "120px" }}
+        >
           <div className="flex flex-col items-center gap-2 text-gray-500">
             <Loader2 className="w-6 h-6 animate-spin" />
             <span className="text-sm">Loading image...</span>
@@ -93,7 +96,10 @@ export const Article: React.FC<ArticleProps> = ({
 
     if (imageError || !imageUrl) {
       return (
-        <div className="w-full sm:w-48 h-32 sm:h-36 bg-gray-100 rounded-lg flex items-center justify-center mb-4 sm:mb-0 sm:mr-4 flex-shrink-0">
+        <div
+          className="w-full sm:w-64 bg-gray-100 rounded-lg flex items-center justify-center mb-4 sm:mb-0 sm:mr-6 flex-shrink-0"
+          style={{ minHeight: "120px" }}
+        >
           <div className="flex flex-col items-center gap-2 text-gray-400">
             <ImageIcon className="w-8 h-8" />
             <span className="text-xs text-center px-2">No image available</span>
@@ -103,11 +109,16 @@ export const Article: React.FC<ArticleProps> = ({
     }
 
     return (
-      <div className="w-full sm:w-48 h-32 sm:h-36 mb-4 sm:mb-0 sm:mr-4 flex-shrink-0">
+      <div className="w-full sm:w-64 mb-4 sm:mb-0 sm:mr-6 flex-shrink-0">
         <img
           src={imageUrl}
           alt={`Wikipedia image for ${title}`}
-          className="w-full h-full object-cover rounded-lg shadow-sm"
+          className="w-full rounded-lg shadow-sm"
+          style={{
+            maxHeight: "300px",
+            height: "auto",
+            objectFit: "contain",
+          }}
           onError={(e) => {
             // Fallback for broken images
             const target = e.target as HTMLImageElement;
@@ -115,10 +126,10 @@ export const Article: React.FC<ArticleProps> = ({
             const parent = target.parentElement;
             if (parent) {
               parent.innerHTML = `
-                <div class="w-full h-full bg-gray-100 rounded-lg flex items-center justify-center">
+                <div class="w-full bg-gray-100 rounded-lg flex items-center justify-center" style="min-height: 120px;">
                   <div class="flex flex-col items-center gap-2 text-gray-400">
                     <svg class="w-8 h-8" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
-                      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 16l4.586-4.586a2 2 0 012.828 0L16 16m-2-2l1.586-1.586a2 2 0 012.828 0L20 14m-6-6h.01M6 20h12a2 2 0 002-2V6a2 2 0 00-2-2H6a2 2 0 00-2 2v12a2 2 0 002 2z"></path>
+                      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 16l4.586-4.586a2 2 0 012.828 0L16 16m-2-2l1.586-1.586a2 2 0 012.828 0L20 14m-6-6h.01M6 20h12a2 2 0 002-2V6a2 2 0 00-2-2H6a2 2 0 002 2z"></path>
                     </svg>
                     <span class="text-xs text-center px-2">Image unavailable</span>
                   </div>

--- a/src/components/wiki-game/Article.tsx
+++ b/src/components/wiki-game/Article.tsx
@@ -79,8 +79,60 @@ export const Article: React.FC<ArticleProps> = ({
     );
   };
 
+  const renderWikipediaImage = () => {
+    if (imageLoading) {
+      return (
+        <div className="w-full sm:w-48 h-32 sm:h-36 bg-gray-100 rounded-lg flex items-center justify-center mb-4 sm:mb-0 sm:mr-4 flex-shrink-0">
+          <div className="flex flex-col items-center gap-2 text-gray-500">
+            <Loader2 className="w-6 h-6 animate-spin" />
+            <span className="text-sm">Loading image...</span>
+          </div>
+        </div>
+      );
+    }
+
+    if (imageError || !imageUrl) {
+      return (
+        <div className="w-full sm:w-48 h-32 sm:h-36 bg-gray-100 rounded-lg flex items-center justify-center mb-4 sm:mb-0 sm:mr-4 flex-shrink-0">
+          <div className="flex flex-col items-center gap-2 text-gray-400">
+            <ImageIcon className="w-8 h-8" />
+            <span className="text-xs text-center px-2">No image available</span>
+          </div>
+        </div>
+      );
+    }
+
+    return (
+      <div className="w-full sm:w-48 h-32 sm:h-36 mb-4 sm:mb-0 sm:mr-4 flex-shrink-0">
+        <img
+          src={imageUrl}
+          alt={`Wikipedia image for ${title}`}
+          className="w-full h-full object-cover rounded-lg shadow-sm"
+          onError={(e) => {
+            // Fallback for broken images
+            const target = e.target as HTMLImageElement;
+            target.style.display = "none";
+            const parent = target.parentElement;
+            if (parent) {
+              parent.innerHTML = `
+                <div class="w-full h-full bg-gray-100 rounded-lg flex items-center justify-center">
+                  <div class="flex flex-col items-center gap-2 text-gray-400">
+                    <svg class="w-8 h-8" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+                      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 16l4.586-4.586a2 2 0 012.828 0L16 16m-2-2l1.586-1.586a2 2 0 012.828 0L20 14m-6-6h.01M6 20h12a2 2 0 002-2V6a2 2 0 00-2-2H6a2 2 0 00-2 2v12a2 2 0 002 2z"></path>
+                    </svg>
+                    <span class="text-xs text-center px-2">Image unavailable</span>
+                  </div>
+                </div>
+              `;
+            }
+          }}
+        />
+      </div>
+    );
+  };
+
   return (
-    <div className="max-w-3xl mx-auto p-6 bg-white rounded-lg shadow-md">
+    <div className="max-w-4xl mx-auto p-6 bg-white rounded-lg shadow-md">
       <div className="flex flex-col">
         <div className="flex flex-col">
           <div className="flex flex-col w-full">
@@ -100,9 +152,19 @@ export const Article: React.FC<ArticleProps> = ({
           </div>
         </div>
       </div>
-      <p className="text-gray-700 leading-loose md:leading-relaxed text-base sm:text-lg md:text-base">
-        {renderArticleContent()}
-      </p>
+
+      {/* Content with image layout */}
+      <div className="flex flex-col sm:flex-row">
+        {/* Wikipedia Image */}
+        {renderWikipediaImage()}
+
+        {/* Article Content */}
+        <div className="flex-1">
+          <p className="text-gray-700 leading-loose md:leading-relaxed text-base sm:text-lg md:text-base">
+            {renderArticleContent()}
+          </p>
+        </div>
+      </div>
     </div>
   );
 };

--- a/src/hooks/use-wikipedia-image.ts
+++ b/src/hooks/use-wikipedia-image.ts
@@ -58,93 +58,154 @@ export const useWikipediaImage = (
     error: null,
   });
 
-  const fetchImage = useCallback(async (title: string) => {
-    // Normalize the title for caching (trim whitespace and handle case)
-    const normalizedTitle = title.trim();
+  const fetchImageFromFile = useCallback(
+    async (filename: string): Promise<string | null> => {
+      try {
+        const imageInfoUrl = new URL("https://en.wikipedia.org/w/api.php");
+        imageInfoUrl.searchParams.set("action", "query");
+        imageInfoUrl.searchParams.set("format", "json");
+        imageInfoUrl.searchParams.set("titles", filename);
+        imageInfoUrl.searchParams.set("prop", "imageinfo");
+        imageInfoUrl.searchParams.set("iiprop", "url");
+        imageInfoUrl.searchParams.set("origin", "*");
 
-    if (!normalizedTitle) {
-      setState({
-        imageUrl: null,
-        isLoading: false,
-        error: "Article title is required",
-      });
-      return;
-    }
+        const response = await fetch(imageInfoUrl.toString());
+        if (!response.ok) return null;
 
-    // Check cache first
-    if (imageCache.has(normalizedTitle)) {
-      const cachedImageUrl = imageCache.get(normalizedTitle);
-      setState({
-        imageUrl: cachedImageUrl,
-        isLoading: false,
-        error: cachedImageUrl === null ? "No image available" : null,
-      });
-      return;
-    }
+        const data: WikipediaImageInfoResponse = await response.json();
+        const pages = data.query?.pages;
+        if (!pages) return null;
 
-    setState((prev) => ({ ...prev, isLoading: true, error: null }));
+        const pageIds = Object.keys(pages);
+        if (pageIds.length === 0) return null;
 
-    try {
-      // Construct Wikipedia API URL with proper parameters
-      const apiUrl = new URL("https://en.wikipedia.org/w/api.php");
-      apiUrl.searchParams.set("action", "query");
-      apiUrl.searchParams.set("format", "json");
-      apiUrl.searchParams.set("prop", "pageimages");
-      apiUrl.searchParams.set("titles", normalizedTitle);
-      apiUrl.searchParams.set("pithumbsize", "300"); // Request larger thumbnail
-      apiUrl.searchParams.set("piprop", "thumbnail");
-      apiUrl.searchParams.set("origin", "*"); // Required for CORS
+        const page = pages[pageIds[0]];
+        return page.imageinfo?.[0]?.url || null;
+      } catch {
+        return null;
+      }
+    },
+    [],
+  );
 
-      const response = await fetch(apiUrl.toString());
+  const fetchImage = useCallback(
+    async (title: string) => {
+      // Normalize the title for caching (trim whitespace and handle case)
+      const normalizedTitle = title.trim();
 
-      if (!response.ok) {
-        throw new Error(`HTTP error! status: ${response.status}`);
+      if (!normalizedTitle) {
+        setState({
+          imageUrl: null,
+          isLoading: false,
+          error: "Article title is required",
+        });
+        return;
       }
 
-      const data: WikipediaApiResponse = await response.json();
-
-      if (!data.query || !data.query.pages) {
-        throw new Error("Invalid API response format");
+      // Check cache first
+      if (imageCache.has(normalizedTitle)) {
+        const cachedImageUrl = imageCache.get(normalizedTitle);
+        setState({
+          imageUrl: cachedImageUrl,
+          isLoading: false,
+          error: cachedImageUrl === null ? "No image available" : null,
+        });
+        return;
       }
 
-      const pages = data.query.pages;
-      const pageIds = Object.keys(pages);
+      setState((prev) => ({ ...prev, isLoading: true, error: null }));
 
-      if (pageIds.length === 0) {
-        throw new Error("No page found for the given title");
+      try {
+        // First try: Get pageimages and all images
+        const apiUrl = new URL("https://en.wikipedia.org/w/api.php");
+        apiUrl.searchParams.set("action", "query");
+        apiUrl.searchParams.set("format", "json");
+        apiUrl.searchParams.set("prop", "pageimages|images");
+        apiUrl.searchParams.set("titles", normalizedTitle);
+        apiUrl.searchParams.set("pithumbsize", "400"); // Request larger thumbnail
+        apiUrl.searchParams.set("piprop", "thumbnail");
+        apiUrl.searchParams.set("imlimit", "10"); // Get first 10 images to find a good one
+        apiUrl.searchParams.set("origin", "*"); // Required for CORS
+
+        const response = await fetch(apiUrl.toString());
+
+        if (!response.ok) {
+          throw new Error(`HTTP error! status: ${response.status}`);
+        }
+
+        const data: WikipediaApiResponse = await response.json();
+
+        if (!data.query || !data.query.pages) {
+          throw new Error("Invalid API response format");
+        }
+
+        const pages = data.query.pages;
+        const pageIds = Object.keys(pages);
+
+        if (pageIds.length === 0) {
+          throw new Error("No page found for the given title");
+        }
+
+        const page = pages[pageIds[0]];
+
+        // Check if the page exists (negative page IDs indicate missing pages)
+        if (page.pageid && page.pageid < 0) {
+          throw new Error("Article not found");
+        }
+
+        let imageUrl = page.thumbnail?.source || null;
+
+        // If no pageimage thumbnail, try to get the first meaningful image from the article
+        if (!imageUrl && page.images && page.images.length > 0) {
+          // Filter out common non-meaningful images
+          const meaningfulImages = page.images.filter((img) => {
+            const filename = img.title.toLowerCase();
+            return (
+              !filename.includes("commons-logo") &&
+              !filename.includes("wikimedia") &&
+              !filename.includes("edit-icon") &&
+              !filename.includes("ambox") &&
+              !filename.includes("stub") &&
+              !filename.includes("flag") &&
+              !filename.includes("symbol") &&
+              !filename.includes(".svg") && // Often icons or symbols
+              (filename.includes(".jpg") ||
+                filename.includes(".jpeg") ||
+                filename.includes(".png"))
+            );
+          });
+
+          // Try to get the URL for the first meaningful image
+          if (meaningfulImages.length > 0) {
+            imageUrl = await fetchImageFromFile(meaningfulImages[0].title);
+          }
+        }
+
+        // Cache the result (null if no image)
+        imageCache.set(normalizedTitle, imageUrl);
+
+        setState({
+          imageUrl,
+          isLoading: false,
+          error:
+            imageUrl === null ? "No image available for this article" : null,
+        });
+      } catch (error) {
+        const errorMessage =
+          error instanceof Error ? error.message : "Failed to fetch image";
+
+        // Cache the failure to avoid repeated failed requests
+        imageCache.set(normalizedTitle, null);
+
+        setState({
+          imageUrl: null,
+          isLoading: false,
+          error: errorMessage,
+        });
       }
-
-      const page = pages[pageIds[0]];
-
-      // Check if the page exists (negative page IDs indicate missing pages)
-      if (page.pageid && page.pageid < 0) {
-        throw new Error("Article not found");
-      }
-
-      const imageUrl = page.thumbnail?.source || null;
-
-      // Cache the result (null if no image)
-      imageCache.set(normalizedTitle, imageUrl);
-
-      setState({
-        imageUrl,
-        isLoading: false,
-        error: imageUrl === null ? "No image available for this article" : null,
-      });
-    } catch (error) {
-      const errorMessage =
-        error instanceof Error ? error.message : "Failed to fetch image";
-
-      // Cache the failure to avoid repeated failed requests
-      imageCache.set(normalizedTitle, null);
-
-      setState({
-        imageUrl: null,
-        isLoading: false,
-        error: errorMessage,
-      });
-    }
-  }, []);
+    },
+    [fetchImageFromFile],
+  );
 
   useEffect(() => {
     if (articleTitle) {

--- a/src/hooks/use-wikipedia-image.ts
+++ b/src/hooks/use-wikipedia-image.ts
@@ -1,0 +1,158 @@
+import { useState, useEffect, useCallback } from "react";
+
+interface WikipediaImageState {
+  imageUrl: string | null;
+  isLoading: boolean;
+  error: string | null;
+}
+
+interface WikipediaApiResponse {
+  query: {
+    pages: {
+      [pageId: string]: {
+        pageid: number;
+        title: string;
+        thumbnail?: {
+          source: string;
+          width: number;
+          height: number;
+        };
+        pageimage?: string;
+      };
+    };
+  };
+}
+
+// In-memory cache to avoid repeated API calls for the same article
+const imageCache = new Map<string, string | null>();
+
+/**
+ * Custom hook to fetch Wikipedia article main image
+ * @param articleTitle - The title of the Wikipedia article
+ * @returns Object containing imageUrl, isLoading, and error states
+ */
+export const useWikipediaImage = (
+  articleTitle: string,
+): WikipediaImageState => {
+  const [state, setState] = useState<WikipediaImageState>({
+    imageUrl: null,
+    isLoading: true,
+    error: null,
+  });
+
+  const fetchImage = useCallback(async (title: string) => {
+    // Normalize the title for caching (trim whitespace and handle case)
+    const normalizedTitle = title.trim();
+
+    if (!normalizedTitle) {
+      setState({
+        imageUrl: null,
+        isLoading: false,
+        error: "Article title is required",
+      });
+      return;
+    }
+
+    // Check cache first
+    if (imageCache.has(normalizedTitle)) {
+      const cachedImageUrl = imageCache.get(normalizedTitle);
+      setState({
+        imageUrl: cachedImageUrl,
+        isLoading: false,
+        error: cachedImageUrl === null ? "No image available" : null,
+      });
+      return;
+    }
+
+    setState((prev) => ({ ...prev, isLoading: true, error: null }));
+
+    try {
+      // Construct Wikipedia API URL with proper parameters
+      const apiUrl = new URL("https://en.wikipedia.org/w/api.php");
+      apiUrl.searchParams.set("action", "query");
+      apiUrl.searchParams.set("format", "json");
+      apiUrl.searchParams.set("prop", "pageimages");
+      apiUrl.searchParams.set("titles", normalizedTitle);
+      apiUrl.searchParams.set("pithumbsize", "300"); // Request larger thumbnail
+      apiUrl.searchParams.set("piprop", "thumbnail");
+      apiUrl.searchParams.set("origin", "*"); // Required for CORS
+
+      const response = await fetch(apiUrl.toString());
+
+      if (!response.ok) {
+        throw new Error(`HTTP error! status: ${response.status}`);
+      }
+
+      const data: WikipediaApiResponse = await response.json();
+
+      if (!data.query || !data.query.pages) {
+        throw new Error("Invalid API response format");
+      }
+
+      const pages = data.query.pages;
+      const pageIds = Object.keys(pages);
+
+      if (pageIds.length === 0) {
+        throw new Error("No page found for the given title");
+      }
+
+      const page = pages[pageIds[0]];
+
+      // Check if the page exists (negative page IDs indicate missing pages)
+      if (page.pageid && page.pageid < 0) {
+        throw new Error("Article not found");
+      }
+
+      const imageUrl = page.thumbnail?.source || null;
+
+      // Cache the result (null if no image)
+      imageCache.set(normalizedTitle, imageUrl);
+
+      setState({
+        imageUrl,
+        isLoading: false,
+        error: imageUrl === null ? "No image available for this article" : null,
+      });
+    } catch (error) {
+      const errorMessage =
+        error instanceof Error ? error.message : "Failed to fetch image";
+
+      // Cache the failure to avoid repeated failed requests
+      imageCache.set(normalizedTitle, null);
+
+      setState({
+        imageUrl: null,
+        isLoading: false,
+        error: errorMessage,
+      });
+    }
+  }, []);
+
+  useEffect(() => {
+    if (articleTitle) {
+      fetchImage(articleTitle);
+    } else {
+      setState({
+        imageUrl: null,
+        isLoading: false,
+        error: "No article title provided",
+      });
+    }
+  }, [articleTitle, fetchImage]);
+
+  return state;
+};
+
+/**
+ * Utility function to clear the image cache (useful for testing or memory management)
+ */
+export const clearWikipediaImageCache = (): void => {
+  imageCache.clear();
+};
+
+/**
+ * Utility function to get cache size (useful for debugging)
+ */
+export const getWikipediaImageCacheSize = (): number => {
+  return imageCache.size();
+};

--- a/src/hooks/use-wikipedia-image.ts
+++ b/src/hooks/use-wikipedia-image.ts
@@ -18,6 +18,24 @@ interface WikipediaApiResponse {
           height: number;
         };
         pageimage?: string;
+        images?: Array<{
+          title: string;
+        }>;
+      };
+    };
+  };
+}
+
+interface WikipediaImageInfoResponse {
+  query: {
+    pages: {
+      [pageId: string]: {
+        imageinfo?: Array<{
+          url: string;
+          descriptionurl: string;
+          width: number;
+          height: number;
+        }>;
       };
     };
   };

--- a/src/hooks/use-wikipedia-image.ts
+++ b/src/hooks/use-wikipedia-image.ts
@@ -233,5 +233,12 @@ export const clearWikipediaImageCache = (): void => {
  * Utility function to get cache size (useful for debugging)
  */
 export const getWikipediaImageCacheSize = (): number => {
-  return imageCache.size();
+  return imageCache.size;
+};
+
+/**
+ * Utility function to check if a specific title is cached
+ */
+export const isWikipediaImageCached = (title: string): boolean => {
+  return imageCache.has(title.trim());
 };


### PR DESCRIPTION
TITLE: Builder.io: Add Wikipedia image display to wiki game articles

tag @builderio-bot for anything you want the bot to do

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 4`

🔗 [Edit in Builder.io](https://builder.io/app/projects/c075b638ea264aed97060850073fac44/quantum-realm)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>c075b638ea264aed97060850073fac44</projectId>-->